### PR TITLE
feat: Enhance basic mode and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,28 @@ A lightweight, fast, and secure wiki application built with Go, HTMX, and Casdoo
 - **Structured Logging:** Configurable, structured logging with `zerolog`.
 - **TLS Support:** Optional TLS/HTTPS support.
 
+### Basic HTML Mode for Legacy Browsers
+
+This wiki is designed to be accessible to a wide range of web browsers, including older or text-based browsers that do not support JavaScript. To achieve this, the application can serve a "Basic HTML Mode."
+
+In this mode:
+- All HTMX and JavaScript-based enhancements are disabled.
+- The rich markdown editor is replaced with a simple textarea.
+- The application serves plain, semantic HTML, ensuring all content is accessible.
+
+This mode is activated in two ways:
+
+1.  **Automatic Detection**: The application automatically enables Basic HTML Mode for known legacy browsers by checking the `User-Agent` string. The current list of detected agents includes:
+    -   `Dillo`
+    -   `Lynx`
+    -   `w3m`
+    -   `NetSurf`
+    -   `AmigaVoyager`
+    -   `Amiga-AWeb`
+    -   `IBrowse`
+
+2.  **Manual Override**: You can force any browser into Basic HTML Mode by adding the `?basic=true` query parameter to the URL. For example: `http://localhost:8080/view/Home?basic=true`.
+
 ### Note on Home Page Content
 
 The default content for the "Home" page, which is displayed when the page does not yet exist in the database, is hardcoded within the application. It is not sourced from an external template file. If you need to change this default message ("Welcome! This page is empty."), you can find it in `internal/handler/page_handler.go` inside the `viewHandler` function.
@@ -49,7 +71,7 @@ The following diagram illustrates the request flow through the application:
                                                      V
                                    +-----------------+-----------------------------+
                                    | Page Repository         | Casbin Enforcer   |
-                                   | - Queries SQLite DB     | - Queries Policies|
+                                   | - Queries MariaDB       | - Queries Policies|
                                    +---------------------------------------------+
 
 ```
@@ -118,7 +140,7 @@ All configuration can be set via environment variables, which override the defau
 | `WIKI_SERVER_TLS_ENABLED`     | Set to `true` to enable HTTPS.                        | `false`                  |
 | `WIKI_SERVER_TLS_CERTFILE`    | Path to the TLS certificate file.                     | `cert.pem`               |
 | `WIKI_SERVER_TLS_KEYFILE`     | Path to the TLS key file.                             | `key.pem`                |
-| `WIKI_DB_DSN`                 | Data Source Name for the database.                    | `wiki.db`                |
+| `WIKI_DB_DSN`                 | Data Source Name for the MariaDB database.            | `wikiuser:wikipass@tcp(mariadb:3306)/go_wiki_app?parseTime=true` |
 | `WIKI_OIDC_ISSUER_URL`        | The issuer URL of your OIDC provider.                 | `http://casdoor.local:8000` |
 | `WIKI_OIDC_CLIENT_ID`         | The client ID for the OIDC application.               | `YOUR_CLIENT_ID`         |
 | `WIKI_OIDC_CLIENT_SECRET`     | The client secret for the OIDC application.           | `YOUR_CLIENT_SECRET`     |

--- a/docker-compose.log
+++ b/docker-compose.log
@@ -1,1 +1,74 @@
--bash: docker-compose: command not found
+time="2025-08-12T17:49:54Z" level=warning msg="/app/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
+#1 [internal] load local bake definitions
+#1 reading from stdin 441B done
+#1 DONE 0.0s
+
+#2 [internal] load build definition from Dockerfile
+#2 transferring dockerfile:
+#2 transferring dockerfile: 1.56kB done
+#2 DONE 0.0s
+
+#3 [internal] load metadata for gcr.io/distroless/static-debian11:latest
+#3 DONE 0.0s
+
+#4 [internal] load metadata for docker.io/library/golang:1.24.3-alpine
+#4 DONE 0.2s
+
+#5 [stage-1 1/6] FROM gcr.io/distroless/static-debian11:latest@sha256:1dbe426d60caed5d19597532a2d74c8056cd7b1674042b88f7328690b5ead8ed
+#5 resolve gcr.io/distroless/static-debian11:latest@sha256:1dbe426d60caed5d19597532a2d74c8056cd7b1674042b88f7328690b5ead8ed 0.0s done
+#5 sha256:1dbe426d60caed5d19597532a2d74c8056cd7b1674042b88f7328690b5ead8ed 1.51kB / 1.51kB done
+#5 sha256:e6d589f36c6c7d9a14df69da026b446ac03c0d2027bfca82981b6a1256c2019c 1.95kB / 1.95kB done
+#5 sha256:9de0a16f3958b01fee65b2775d8616d2762f023a9ec6badb35cc853cc0eada1e 1.49kB / 1.49kB done
+#5 extracting sha256:1c56d6035a42c0a75d79cc88acf6c9d4104343639f19b8262b520c449731445d done
+#5 extracting sha256:e33bce57de289fffd2380f73997dfb7e1ec193877904bed99f28c715d071fdc4 done
+#5 sha256:1c56d6035a42c0a75d79cc88acf6c9d4104343639f19b8262b520c449731445d 104.12kB / 104.12kB 0.1s done
+#5 sha256:e33bce57de289fffd2380f73997dfb7e1ec193877904bed99f28c715d071fdc4 21.19kB / 21.19kB 0.1s done
+#5 sha256:473d8557b1b27974f7dc7c4b4e1a209df0e27e8cae1e3e33b7bb45c969b6fc7e 755.28kB / 755.28kB 0.1s done
+#5 sha256:7c12895b777bcaa8ccae0605b4de635b68fc32d60fa08f421dc3818bf55ee212 188B / 188B 0.2s done
+#5 sha256:33e068de264953dfdc9f9ada207e76b61159721fd64a4820b320d05133a55fb8 122B / 122B 0.2s done
+#5 sha256:27be814a09ebd97fac6fb7b82d19f117185e90601009df3fbab6f442f85cd6b3 93B / 93B 0.3s done
+#5 sha256:b6824ed73363f94b3b2b44084c51c31bc32af77a96861d49e16f91e3ab6bed71 67B / 67B 0.2s done
+#5 sha256:5664b15f108bf9436ce3312090a767300800edbbfd4511aa1a6d64357024d5dd 168B / 168B 0.3s done
+#5 sha256:4aa0ea1413d37a58615488592a0b827ea4b2e48fa5a77cf707d0e35f025e613f 385B / 385B 0.3s done
+#5 sha256:9112d77ee5b16873acaa186b816c3c61f5f8eba40730e729e9614a27f40211e0 122.56kB / 122.56kB 0.4s done
+#5 sha256:9ef7d74bdfdf3c517b28bd694a9159e94e5f53ff1ca87b39f8ca1ac0be2ed317 320B / 320B 0.4s done
+#5 extracting sha256:473d8557b1b27974f7dc7c4b4e1a209df0e27e8cae1e3e33b7bb45c969b6fc7e 0.8s done
+#5 extracting sha256:b6824ed73363f94b3b2b44084c51c31bc32af77a96861d49e16f91e3ab6bed71 done
+#5 extracting sha256:7c12895b777bcaa8ccae0605b4de635b68fc32d60fa08f421dc3818bf55ee212 done
+#5 extracting sha256:33e068de264953dfdc9f9ada207e76b61159721fd64a4820b320d05133a55fb8 done
+#5 extracting sha256:5664b15f108bf9436ce3312090a767300800edbbfd4511aa1a6d64357024d5dd done
+#5 extracting sha256:27be814a09ebd97fac6fb7b82d19f117185e90601009df3fbab6f442f85cd6b3 done
+#5 extracting sha256:4aa0ea1413d37a58615488592a0b827ea4b2e48fa5a77cf707d0e35f025e613f done
+#5 extracting sha256:9ef7d74bdfdf3c517b28bd694a9159e94e5f53ff1ca87b39f8ca1ac0be2ed317 done
+#5 extracting sha256:9112d77ee5b16873acaa186b816c3c61f5f8eba40730e729e9614a27f40211e0 0.0s done
+#5 DONE 4.0s
+
+#6 [stage-1 2/6] WORKDIR /app
+#6 DONE 0.3s
+
+#7 [builder 1/6] FROM docker.io/library/golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1
+#7 resolve docker.io/library/golang:1.24.3-alpine@sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1 0.0s done
+#7 sha256:ee6ed942a4adbd5fff6accec75d55baab0125eb21f31c26144ba0e8d3da49914 2.08kB / 2.08kB done
+#7 sha256:b4f875e650466fa0fe62c6fd3f02517a392123eea85f1d7e69d85f780e4db1c1 10.29kB / 10.29kB done
+#7 sha256:26e5827d0bcee61db5b976014a99018c1ff8f8e6248de8f3ee85bf12229c4b34 1.92kB / 1.92kB done
+#7 sha256:965f7aff83c4fc694f4ad4c3166a22df4df5eb2caf149cfdbe8a2bb6af7ebdb5 294.90kB / 294.90kB 0.7s done
+#7 sha256:fe07684b16b82247c3539ed86a65ff37a76138ec25d380bd80c869a1a4c73236 3.80MB / 3.80MB 0.8s done
+#7 extracting sha256:fe07684b16b82247c3539ed86a65ff37a76138ec25d380bd80c869a1a4c73236 0.3s done
+#7 sha256:87ee4818046b39b38d9211e2793dfd046836a88da1dcbf0df5855493ba4c368a 127B / 127B 1.3s done
+#7 sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B 1.4s done
+#7 extracting sha256:965f7aff83c4fc694f4ad4c3166a22df4df5eb2caf149cfdbe8a2bb6af7ebdb5 0.2s done
+#7 sha256:92b00dc8dfbaa6cd7e39d09d4f1c726259b4d9a29c697192955da032f472d642 78.98MB / 78.98MB 4.3s done
+#7 extracting sha256:92b00dc8dfbaa6cd7e39d09d4f1c726259b4d9a29c697192955da032f472d642 10.7s done
+#7 extracting sha256:87ee4818046b39b38d9211e2793dfd046836a88da1dcbf0df5855493ba4c368a done
+#7 extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 done
+#7 DONE 27.9s
+
+#8 [internal] load .dockerignore
+#8 transferring context: 2B done
+#8 DONE 0.0s
+
+#9 [internal] load build context
+#9 transferring context: 266.96kB 0.0s done
+#9 DONE 0.3s
+
+#10 [builder 2/6] WORKDIR /app

--- a/internal/middleware/settings.go
+++ b/internal/middleware/settings.go
@@ -4,14 +4,46 @@ import (
 	"context"
 	"go-wiki-app/internal/view"
 	"net/http"
+	"strings"
 )
 
-// SettingsMiddleware checks for a "basic=true" query parameter and sets a corresponding
-// flag in the request context. This allows downstream handlers and templates to
-// disable features like HTMX for a simpler, basic HTML experience.
+// legacyUserAgents contains substrings of User-Agent headers for browsers
+// that are known to not support JavaScript or HTMX well.
+var legacyUserAgents = []string{
+	"Dillo",      // A graphical web browser known for its speed and small footprint.
+	"Lynx",       // A classic text-based web browser.
+	"w3m",        // Another popular text-based web browser.
+	"NetSurf",    // A lightweight open-source browser with its own layout engine.
+	"AmigaVoyager", // Web browser for AmigaOS.
+	"Amiga-AWeb", // Another web browser for AmigaOS.
+	"IBrowse",    // A web browser for AmigaOS.
+}
+
+// isLegacyBrowser checks if the User-Agent string matches known legacy browsers.
+func isLegacyBrowser(userAgent string) bool {
+	for _, ua := range legacyUserAgents {
+		if strings.Contains(userAgent, ua) {
+			return true
+		}
+	}
+	return false
+}
+
+// SettingsMiddleware checks for a "basic=true" query parameter or a legacy browser
+// User-Agent and sets a corresponding flag in the request context. This allows
+// downstream handlers and templates to disable features like HTMX for a simpler,
+// basic HTML experience.
 func SettingsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Start with the manual query parameter check.
 		basicMode := r.URL.Query().Get("basic") == "true"
+
+		// If not manually set, check the User-Agent for legacy browsers.
+		if !basicMode {
+			userAgent := r.Header.Get("User-Agent")
+			basicMode = isLegacyBrowser(userAgent)
+		}
+
 		ctx := context.WithValue(r.Context(), view.BasicModeKey, basicMode)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/project_structure.md
+++ b/project_structure.md
@@ -1,0 +1,26 @@
+# Project Structure
+
+This document outlines the directory structure of the Go Wiki application, explaining the purpose of each major file and folder.
+
+-   `cmd/`: Application entry points.
+    -   `cmd/server/main.go`: The main entry point for the web server. It initializes all dependencies and starts the HTTP server.
+-   `internal/`: Contains the core application logic, structured by domain.
+    -   `internal/auth/`: Handles authentication (OIDC) and authorization (Casbin) logic.
+    -   `internal/config/`: Manages application configuration, loading from files and environment variables.
+    -   `internal/data/`: Responsible for database interactions, including models (`models.go`) and the repository layer (`page_repository.go`).
+    -   `internal/handler/`: Contains the HTTP handlers that respond to web requests (e.g., `page_handler.go`, `auth_handler.go`). It maps routes to business logic.
+    -   `internal/middleware/`: Implements HTTP middleware for tasks like logging, authentication checks, and setting request-scoped values.
+    -   `internal/service/`: Contains the core business logic of the application (e.g., `page_service.go`). Handlers call services to perform actions.
+    -   `internal/session/`: Manages user sessions.
+    -   `internal/view/`: Handles the rendering of HTML templates.
+-   `web/`: Contains all frontend assets.
+    -   `web/static/`: Static files like CSS and images.
+    -   `web/templates/`: HTML templates used for rendering pages.
+        -   `layouts/`: Base layout templates.
+        -   `pages/`: Templates for specific pages (view, edit, etc.).
+    -   `web/embed.go`: Uses Go's `embed` package to bundle the `static` and `templates` directories into the application binary.
+-   `migrations/`: SQL database migration files.
+-   `docker/`: Contains Docker-related files, such as `init.sql` for the database.
+-   `config.yml`: Default configuration file.
+-   `docker-compose.yml`: Defines the services, networks, and volumes for the Docker application stack.
+-   `go.mod`, `go.sum`: Go module files for managing project dependencies.


### PR DESCRIPTION
This commit introduces automatic detection for legacy browsers to serve a plain HTML version of the site, improving accessibility. It also adds new project structure documentation and corrects inaccuracies in the README.

Key changes:
- middleware: Updated SettingsMiddleware to check the User-Agent and automatically enable basic mode for browsers like Dillo and Lynx.
- docs: Created project_structure.md to outline the repository layout.
- docs: Updated README.md to document the new basic mode feature.
- docs: Corrected README.md to specify MariaDB instead of SQLite, aligning the documentation with the actual implementation.