### PR TITLE
feat: Use local static assets instead of CDN

### DIFF
--- a/web/templates/layouts/base.html
+++ b/web/templates/layouts/base.html
@@ -7,9 +7,9 @@
     <title>{{block "title" .}}Go Wiki{{end}}</title>
     <link rel="stylesheet" href="/static/css/pico.min.css">
     {{if not .IsBasicMode}}
-    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
-    <link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
-    <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
+    <script src="/static/js/htmx.min.js"></script>
+    <link rel="stylesheet" href="/static/css/easymde.min.css">
+    <script src="/static/js/easymde.min.js"></script>
     <style>
         /* Aggressive override to isolate EasyMDE from Pico.css */
         .editor-toolbar button {


### PR DESCRIPTION
Replaced unpkg.com links for htmx and EasyMDE with local static files to improve website loading speed and reliability.